### PR TITLE
added conflict detection so that manual_references does not need skipping

### DIFF
--- a/lib/transformer.ex
+++ b/lib/transformer.ex
@@ -9,25 +9,15 @@ defmodule AshPostgresBelongsToIndex.Transformer do
 
   def transform(dsl_state) do
     except_list = Transformer.get_option(dsl_state, [:postgres_belongs_to_index], :except, [])
-
-    manual_references =
-      Transformer.get_entities(dsl_state, [:postgres, :references])
-      |> Enum.map(& &1.relationship)
+    multitenant_attr = Transformer.get_option(dsl_state, [:multitenancy], :attribute)
+    manual_references = Transformer.get_entities(dsl_state, [:postgres, :references])
 
     dsl_state
     |> get_belongs_toes()
-    |> Enum.reject(fn %BelongsTo{name: name} -> name in except_list end)
-    |> Enum.reject(fn %BelongsTo{name: name} -> name in manual_references end)
-    |> Enum.reduce(dsl_state, fn %BelongsTo{name: name}, dsl_state ->
-      {:ok, reference} =
-        Transformer.build_entity(AshPostgres.DataLayer, [:postgres, :references], :reference,
-          relationship: name,
-          index?: true
-        )
-
-      dsl_state |> Transformer.add_entity([:postgres, :references], reference, type: :append)
-    end)
-    |> then(fn dsl_state -> {:ok, dsl_state} end)
+    |> reject_excluded_relationships(except_list)
+    |> reject_already_indexed_relationships(dsl_state, manual_references, multitenant_attr)
+    |> add_missing_indexes(dsl_state, manual_references, multitenant_attr)
+    |> then(&{:ok, &1})
   end
 
   def get_belongs_toes(dsl_state) do
@@ -39,5 +29,111 @@ defmodule AshPostgresBelongsToIndex.Transformer do
       %BelongsTo{source_attribute: source_attribute} -> source_attribute != multitenant_attr
       %{} -> false
     end)
+  end
+
+  defp reject_excluded_relationships(belongs_tos, except_list) do
+    Enum.reject(belongs_tos, fn %BelongsTo{name: name} -> name in except_list end)
+  end
+
+  defp reject_already_indexed_relationships(
+         belongs_tos,
+         dsl_state,
+         manual_references,
+         multitenant_attr
+       ) do
+    Enum.reject(
+      belongs_tos,
+      &already_indexed?(&1, dsl_state, manual_references, multitenant_attr)
+    )
+  end
+
+  defp already_indexed?(
+         %BelongsTo{name: name, source_attribute: source_attr},
+         dsl_state,
+         manual_references,
+         multitenant_attr
+       ) do
+    has_indexed_manual_reference?(name, manual_references) ||
+      has_existing_custom_index?(dsl_state, source_attr, multitenant_attr)
+  end
+
+  defp has_indexed_manual_reference?(relationship_name, manual_references) do
+    Enum.any?(manual_references, fn ref ->
+      ref.relationship == relationship_name && ref.index? == true
+    end)
+  end
+
+  defp has_existing_custom_index?(dsl_state, fk_attribute, multitenant_attr) do
+    dsl_state
+    |> Transformer.get_entities([:postgres, :custom_indexes])
+    |> Enum.any?(&index_covers_fk?(&1, fk_attribute, multitenant_attr))
+  end
+
+  defp add_missing_indexes(belongs_tos, dsl_state, manual_references, multitenant_attr) do
+    Enum.reduce(belongs_tos, dsl_state, fn belongs_to, acc_dsl_state ->
+      add_index_for_relationship(belongs_to, acc_dsl_state, manual_references, multitenant_attr)
+    end)
+  end
+
+  defp add_index_for_relationship(
+         %BelongsTo{name: name, source_attribute: source_attr},
+         dsl_state,
+         manual_references,
+         multitenant_attr
+       ) do
+    case has_manual_reference?(name, manual_references) do
+      true -> add_custom_index(dsl_state, source_attr, multitenant_attr)
+      false -> add_indexed_reference(dsl_state, name)
+    end
+  end
+
+  defp has_manual_reference?(relationship_name, manual_references) do
+    Enum.any?(manual_references, fn ref -> ref.relationship == relationship_name end)
+  end
+
+  defp add_custom_index(dsl_state, source_attr, multitenant_attr) do
+    index_fields = build_index_fields(source_attr, multitenant_attr)
+
+    {:ok, index} =
+      Transformer.build_entity(
+        AshPostgres.DataLayer,
+        [:postgres, :custom_indexes],
+        :index,
+        fields: index_fields
+      )
+
+    Transformer.add_entity(dsl_state, [:postgres, :custom_indexes], index, type: :append)
+  end
+
+  defp add_indexed_reference(dsl_state, relationship_name) do
+    {:ok, reference} =
+      Transformer.build_entity(
+        AshPostgres.DataLayer,
+        [:postgres, :references],
+        :reference,
+        relationship: relationship_name,
+        index?: true
+      )
+
+    Transformer.add_entity(dsl_state, [:postgres, :references], reference, type: :append)
+  end
+
+  defp build_index_fields(source_attr, nil), do: [source_attr]
+  defp build_index_fields(source_attr, tenant_attr), do: [tenant_attr, source_attr]
+
+  defp index_covers_fk?(index, fk_attribute, multitenant_attr) do
+    index_columns = index.fields || []
+
+    case multitenant_attr do
+      nil ->
+        index_columns == [fk_attribute]
+
+      tenant_attr when is_atom(tenant_attr) ->
+        # For multitenant resources, accept both composite [:tenant_id, :fk_id] and simple [:fk_id] indexes.
+        # Simple indexes are acceptable because PostgreSQL can efficiently use composite indexes 
+        # (like [:tenant_id, :fk_id]) for single-column queries on the first column, but existing
+        # simple indexes may have been created for specific query patterns or before multitenancy.
+        index_columns == [tenant_attr, fk_attribute] or index_columns == [fk_attribute]
+    end
   end
 end

--- a/lib/transformer.ex
+++ b/lib/transformer.ex
@@ -150,7 +150,7 @@ defmodule AshPostgresBelongsToIndex.Transformer do
     Enum.any?(manual_references, fn ref -> ref.relationship == relationship_name end)
   end
 
-  defp add_custom_index(dsl_state, fields, opts \\ []) do
+  defp add_custom_index(dsl_state, fields, opts) do
     {:ok, index} =
       Transformer.build_entity(
         AshPostgres.DataLayer,

--- a/lib/transformer.ex
+++ b/lib/transformer.ex
@@ -21,12 +21,10 @@ defmodule AshPostgresBelongsToIndex.Transformer do
   end
 
   def get_belongs_toes(dsl_state) do
-    multitenant_attr = dsl_state |> Transformer.get_option([:multitenancy], :attribute)
-
     dsl_state
     |> Transformer.get_entities([:relationships])
     |> Enum.filter(fn
-      %BelongsTo{source_attribute: source_attribute} -> source_attribute != multitenant_attr
+      %BelongsTo{} -> true
       %{} -> false
     end)
   end
@@ -90,22 +88,39 @@ defmodule AshPostgresBelongsToIndex.Transformer do
   end
 
   defp add_missing_indexes(belongs_tos, dsl_state, manual_references, multitenant_attr) do
-    Enum.reduce(belongs_tos, dsl_state, fn belongs_to, acc_dsl_state ->
-      add_index_for_relationship(belongs_to, acc_dsl_state, manual_references, multitenant_attr)
+    # First pass: add composite indexes for non-tenant relationships
+    dsl_state =
+      Enum.reduce(belongs_tos, dsl_state, fn belongs_to, acc ->
+        add_composite_index_for_relationship(belongs_to, acc, manual_references, multitenant_attr)
+      end)
+
+    # Second pass: add single-column indexes where needed
+    Enum.reduce(belongs_tos, dsl_state, fn belongs_to, acc ->
+      add_single_column_index_for_relationship(belongs_to, acc, multitenant_attr)
     end)
   end
 
-  defp add_index_for_relationship(
+  defp add_composite_index_for_relationship(
          %BelongsTo{name: name, source_attribute: source_attr},
          dsl_state,
          manual_references,
          multitenant_attr
        ) do
-    has_manual_ref = has_manual_reference?(name, manual_references)
+    # Skip composite index if source_attr == tenant_attr (would be redundant [:company_id, :company_id])
+    if source_attr == multitenant_attr do
+      dsl_state
+    else
+      has_manual_ref = has_manual_reference?(name, manual_references)
+      ensure_composite_index(dsl_state, name, source_attr, multitenant_attr, has_manual_ref, manual_references)
+    end
+  end
 
-    dsl_state
-    |> ensure_composite_index(name, source_attr, multitenant_attr, has_manual_ref, manual_references)
-    |> ensure_single_column_index(source_attr, multitenant_attr)
+  defp add_single_column_index_for_relationship(
+         %BelongsTo{source_attribute: source_attr},
+         dsl_state,
+         multitenant_attr
+       ) do
+    ensure_single_column_index(dsl_state, source_attr, multitenant_attr)
   end
 
   defp ensure_composite_index(
@@ -135,10 +150,40 @@ defmodule AshPostgresBelongsToIndex.Transformer do
   defp ensure_single_column_index(dsl_state, _source_attr, nil), do: dsl_state
 
   defp ensure_single_column_index(dsl_state, source_attr, tenant_attr) do
-    if has_custom_index_on?(dsl_state, [source_attr], tenant_attr) do
+    # Only create single-column index if no existing index covers this column
+    # as the leftmost field (which can satisfy FK lookups via prefix rule)
+    if has_index_starting_with?(dsl_state, source_attr, tenant_attr) do
       dsl_state
     else
       add_custom_index(dsl_state, [source_attr], all_tenants?: true)
+    end
+  end
+
+  defp has_index_starting_with?(dsl_state, field, multitenant_attr) do
+    has_custom_index_starting_with?(dsl_state, field, multitenant_attr) ||
+      has_indexed_reference_starting_with?(dsl_state, field, multitenant_attr)
+  end
+
+  defp has_custom_index_starting_with?(dsl_state, field, multitenant_attr) do
+    dsl_state
+    |> Transformer.get_entities([:postgres, :custom_indexes])
+    |> Enum.any?(fn idx ->
+      effective_fields = effective_index_fields(idx, multitenant_attr)
+      List.first(effective_fields) == field
+    end)
+  end
+
+  defp has_indexed_reference_starting_with?(dsl_state, field, multitenant_attr) do
+    # Indexed references create composite indexes starting with tenant_attr (if multitenant)
+    # or with the FK column (if non-multitenant)
+    case multitenant_attr do
+      nil -> false
+      tenant_attr ->
+        # If looking for tenant_attr and there's any indexed reference, it will start with tenant_attr
+        field == tenant_attr &&
+          dsl_state
+          |> Transformer.get_entities([:postgres, :references])
+          |> Enum.any?(& &1.index?)
     end
   end
 

--- a/lib/transformer.ex
+++ b/lib/transformer.ex
@@ -55,9 +55,9 @@ defmodule AshPostgresBelongsToIndex.Transformer do
        ) do
     has_composite =
       has_indexed_manual_reference?(name, manual_references) ||
-        has_custom_index_on?(dsl_state, build_index_fields(source_attr, multitenant_attr))
+        has_custom_index_on?(dsl_state, build_index_fields(source_attr, multitenant_attr), multitenant_attr)
 
-    has_single = has_custom_index_on?(dsl_state, [source_attr])
+    has_single = has_custom_index_on?(dsl_state, [source_attr], multitenant_attr)
 
     case multitenant_attr do
       nil -> has_composite || has_single
@@ -71,10 +71,22 @@ defmodule AshPostgresBelongsToIndex.Transformer do
     end)
   end
 
-  defp has_custom_index_on?(dsl_state, fields) do
+  defp has_custom_index_on?(dsl_state, effective_fields, multitenant_attr) do
     dsl_state
     |> Transformer.get_entities([:postgres, :custom_indexes])
-    |> Enum.any?(fn idx -> (idx.fields || []) == fields end)
+    |> Enum.any?(fn idx ->
+      effective_index_fields(idx, multitenant_attr) == effective_fields
+    end)
+  end
+
+  defp effective_index_fields(idx, multitenant_attr) do
+    fields = idx.fields || []
+
+    case {multitenant_attr, idx.all_tenants?} do
+      {nil, _} -> fields
+      {_, true} -> fields
+      {tenant_attr, _} -> [tenant_attr | fields]
+    end
   end
 
   defp add_missing_indexes(belongs_tos, dsl_state, manual_references, multitenant_attr) do
@@ -107,23 +119,27 @@ defmodule AshPostgresBelongsToIndex.Transformer do
     composite_fields = build_index_fields(source_attr, multitenant_attr)
 
     already_has_composite =
-      has_custom_index_on?(dsl_state, composite_fields) ||
+      has_custom_index_on?(dsl_state, composite_fields, multitenant_attr) ||
         has_indexed_manual_reference?(name, manual_references)
 
     if already_has_composite do
       dsl_state
     else
       case has_manual_ref do
-        true -> add_custom_index(dsl_state, composite_fields)
-        false -> add_indexed_reference(dsl_state, name)
+        true ->
+          opts = if multitenant_attr, do: [all_tenants?: true], else: []
+          add_custom_index(dsl_state, composite_fields, opts)
+
+        false ->
+          add_indexed_reference(dsl_state, name)
       end
     end
   end
 
   defp ensure_single_column_index(dsl_state, _source_attr, nil), do: dsl_state
 
-  defp ensure_single_column_index(dsl_state, source_attr, _tenant_attr) do
-    if has_custom_index_on?(dsl_state, [source_attr]) do
+  defp ensure_single_column_index(dsl_state, source_attr, tenant_attr) do
+    if has_custom_index_on?(dsl_state, [source_attr], tenant_attr) do
       dsl_state
     else
       add_custom_index(dsl_state, [source_attr], all_tenants?: true)

--- a/lib/transformer.ex
+++ b/lib/transformer.ex
@@ -85,7 +85,7 @@ defmodule AshPostgresBelongsToIndex.Transformer do
     case {multitenant_attr, idx.all_tenants?} do
       {nil, _} -> fields
       {_, true} -> fields
-      {tenant_attr, _} -> [tenant_attr | fields]
+      {tenant_attr, _} -> Enum.uniq([tenant_attr | fields])
     end
   end
 
@@ -126,12 +126,8 @@ defmodule AshPostgresBelongsToIndex.Transformer do
       dsl_state
     else
       case has_manual_ref do
-        true ->
-          opts = if multitenant_attr, do: [all_tenants?: true], else: []
-          add_custom_index(dsl_state, composite_fields, opts)
-
-        false ->
-          add_indexed_reference(dsl_state, name)
+        true -> add_custom_index(dsl_state, composite_fields, [])
+        false -> add_indexed_reference(dsl_state, name)
       end
     end
   end

--- a/lib/transformer.ex
+++ b/lib/transformer.ex
@@ -53,8 +53,16 @@ defmodule AshPostgresBelongsToIndex.Transformer do
          manual_references,
          multitenant_attr
        ) do
-    has_indexed_manual_reference?(name, manual_references) ||
-      has_existing_custom_index?(dsl_state, source_attr, multitenant_attr)
+    has_composite =
+      has_indexed_manual_reference?(name, manual_references) ||
+        has_custom_index_on?(dsl_state, build_index_fields(source_attr, multitenant_attr))
+
+    has_single = has_custom_index_on?(dsl_state, [source_attr])
+
+    case multitenant_attr do
+      nil -> has_composite || has_single
+      _tenant_attr -> has_composite && has_single
+    end
   end
 
   defp has_indexed_manual_reference?(relationship_name, manual_references) do
@@ -63,10 +71,10 @@ defmodule AshPostgresBelongsToIndex.Transformer do
     end)
   end
 
-  defp has_existing_custom_index?(dsl_state, fk_attribute, multitenant_attr) do
+  defp has_custom_index_on?(dsl_state, fields) do
     dsl_state
     |> Transformer.get_entities([:postgres, :custom_indexes])
-    |> Enum.any?(&index_covers_fk?(&1, fk_attribute, multitenant_attr))
+    |> Enum.any?(fn idx -> (idx.fields || []) == fields end)
   end
 
   defp add_missing_indexes(belongs_tos, dsl_state, manual_references, multitenant_attr) do
@@ -81,9 +89,44 @@ defmodule AshPostgresBelongsToIndex.Transformer do
          manual_references,
          multitenant_attr
        ) do
-    case has_manual_reference?(name, manual_references) do
-      true -> add_custom_index(dsl_state, source_attr, multitenant_attr)
-      false -> add_indexed_reference(dsl_state, name)
+    has_manual_ref = has_manual_reference?(name, manual_references)
+
+    dsl_state
+    |> ensure_composite_index(name, source_attr, multitenant_attr, has_manual_ref, manual_references)
+    |> ensure_single_column_index(source_attr, multitenant_attr)
+  end
+
+  defp ensure_composite_index(
+         dsl_state,
+         name,
+         source_attr,
+         multitenant_attr,
+         has_manual_ref,
+         manual_references
+       ) do
+    composite_fields = build_index_fields(source_attr, multitenant_attr)
+
+    already_has_composite =
+      has_custom_index_on?(dsl_state, composite_fields) ||
+        has_indexed_manual_reference?(name, manual_references)
+
+    if already_has_composite do
+      dsl_state
+    else
+      case has_manual_ref do
+        true -> add_custom_index(dsl_state, composite_fields)
+        false -> add_indexed_reference(dsl_state, name)
+      end
+    end
+  end
+
+  defp ensure_single_column_index(dsl_state, _source_attr, nil), do: dsl_state
+
+  defp ensure_single_column_index(dsl_state, source_attr, _tenant_attr) do
+    if has_custom_index_on?(dsl_state, [source_attr]) do
+      dsl_state
+    else
+      add_custom_index(dsl_state, [source_attr], all_tenants?: true)
     end
   end
 
@@ -91,15 +134,13 @@ defmodule AshPostgresBelongsToIndex.Transformer do
     Enum.any?(manual_references, fn ref -> ref.relationship == relationship_name end)
   end
 
-  defp add_custom_index(dsl_state, source_attr, multitenant_attr) do
-    index_fields = build_index_fields(source_attr, multitenant_attr)
-
+  defp add_custom_index(dsl_state, fields, opts \\ []) do
     {:ok, index} =
       Transformer.build_entity(
         AshPostgres.DataLayer,
         [:postgres, :custom_indexes],
         :index,
-        fields: index_fields
+        Keyword.merge([fields: fields], opts)
       )
 
     Transformer.add_entity(dsl_state, [:postgres, :custom_indexes], index, type: :append)
@@ -120,20 +161,4 @@ defmodule AshPostgresBelongsToIndex.Transformer do
 
   defp build_index_fields(source_attr, nil), do: [source_attr]
   defp build_index_fields(source_attr, tenant_attr), do: [tenant_attr, source_attr]
-
-  defp index_covers_fk?(index, fk_attribute, multitenant_attr) do
-    index_columns = index.fields || []
-
-    case multitenant_attr do
-      nil ->
-        index_columns == [fk_attribute]
-
-      tenant_attr when is_atom(tenant_attr) ->
-        # For multitenant resources, accept both composite [:tenant_id, :fk_id] and simple [:fk_id] indexes.
-        # Simple indexes are acceptable because PostgreSQL can efficiently use composite indexes 
-        # (like [:tenant_id, :fk_id]) for single-column queries on the first column, but existing
-        # simple indexes may have been created for specific query patterns or before multitenancy.
-        index_columns == [tenant_attr, fk_attribute] or index_columns == [fk_attribute]
-    end
-  end
 end

--- a/test/support/test_resources.ex
+++ b/test/support/test_resources.ex
@@ -1,0 +1,135 @@
+defmodule AshPostgresBelongsToIndex.Test.Support.TestResources do
+  @moduledoc """
+  Test helper resources for testing the transformer
+  """
+
+  defmodule TestRepo do
+    @moduledoc false
+    use AshPostgres.Repo,
+      otp_app: :ash_postgres_belongs_to_index,
+      warn_on_missing_ash_functions?: false
+
+    def min_pg_version do
+      %Version{major: 16, minor: 0, patch: 0}
+    end
+  end
+
+  defmodule CompanyResource do
+    @moduledoc false
+    use Ash.Resource,
+      domain: nil,
+      data_layer: AshPostgres.DataLayer,
+      validate_domain_inclusion?: false
+
+    postgres do
+      table "companies"
+      repo TestRepo
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string
+    end
+  end
+
+  defmodule UserResource do
+    @moduledoc false
+    use Ash.Resource,
+      domain: nil,
+      data_layer: AshPostgres.DataLayer,
+      validate_domain_inclusion?: false
+
+    postgres do
+      table "users"
+      repo TestRepo
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :email, :string
+    end
+  end
+
+  defmodule DepotResource do
+    @moduledoc false
+    use Ash.Resource,
+      domain: nil,
+      data_layer: AshPostgres.DataLayer,
+      validate_domain_inclusion?: false
+
+    postgres do
+      table "depots"
+      repo TestRepo
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :name, :string
+    end
+  end
+
+  defmodule MultitenantOrderResource do
+    @moduledoc false
+    use Ash.Resource,
+      domain: nil,
+      data_layer: AshPostgres.DataLayer,
+      extensions: [AshPostgresBelongsToIndex],
+      validate_domain_inclusion?: false
+
+    postgres do
+      table "multitenant_orders"
+      repo TestRepo
+    end
+
+    multitenancy do
+      strategy :attribute
+      attribute :company_id
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :order_number, :string
+    end
+
+    relationships do
+      belongs_to :company, CompanyResource
+      belongs_to :user, UserResource
+      belongs_to :depot, DepotResource
+    end
+  end
+
+  defmodule MultitenantOrderWithRefsResource do
+    @moduledoc false
+    use Ash.Resource,
+      domain: nil,
+      data_layer: AshPostgres.DataLayer,
+      extensions: [AshPostgresBelongsToIndex],
+      validate_domain_inclusion?: false
+
+    postgres do
+      table "multitenant_orders_with_refs"
+      repo TestRepo
+
+      references do
+        reference :company, on_delete: :delete
+        reference :user, on_delete: :nilify
+      end
+    end
+
+    multitenancy do
+      strategy :attribute
+      attribute :company_id
+    end
+
+    attributes do
+      uuid_primary_key :id
+      attribute :order_number, :string
+    end
+
+    relationships do
+      belongs_to :company, CompanyResource
+      belongs_to :user, UserResource
+      belongs_to :depot, DepotResource
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,4 @@
 ExUnit.start()
+
+# Load test support files
+Code.require_file("support/test_resources.ex", __DIR__)

--- a/test/transformer_test.exs
+++ b/test/transformer_test.exs
@@ -1,0 +1,482 @@
+defmodule AshPostgresBelongsToIndex.TransformerTest do
+  use ExUnit.Case, async: true
+
+  alias AshPostgresBelongsToIndex.Transformer
+  alias Spark.Dsl.Transformer, as: DslTransformer
+
+  describe "transformer behavior" do
+    test "creates indexed references for resources without manual references" do
+      # Define a simple resource without manual references
+      defmodule SimpleResource do
+        use Ash.Resource,
+          domain: nil,
+          data_layer: AshPostgres.DataLayer,
+          extensions: [AshPostgresBelongsToIndex],
+          validate_domain_inclusion?: false
+
+        postgres do
+          table "simple_resource"
+          repo AshPostgresBelongsToIndex.Test.Support.TestResources.TestRepo
+        end
+
+        attributes do
+          uuid_primary_key :id
+          attribute :name, :string
+        end
+
+        relationships do
+          belongs_to :company,
+                     AshPostgresBelongsToIndex.Test.Support.TestResources.CompanyResource
+
+          belongs_to :user, AshPostgresBelongsToIndex.Test.Support.TestResources.UserResource
+        end
+      end
+
+      dsl_state = SimpleResource.spark_dsl_config()
+      {:ok, transformed_state} = Transformer.transform(dsl_state)
+
+      # Should create indexed references, not custom indexes
+      references = DslTransformer.get_entities(transformed_state, [:postgres, :references])
+
+      custom_indexes =
+        DslTransformer.get_entities(transformed_state, [:postgres, :custom_indexes])
+
+      # Should have references with index?: true
+      assert length(references) == 2
+      company_ref = Enum.find(references, &(&1.relationship == :company))
+      user_ref = Enum.find(references, &(&1.relationship == :user))
+
+      assert company_ref.index? == true
+      assert user_ref.index? == true
+
+      # Should not create custom indexes
+      assert length(custom_indexes) == 0
+    end
+
+    test "creates custom indexes for resources with existing manual references" do
+      # Define a resource with manual references (no index?)
+      defmodule ResourceWithManualRefs do
+        use Ash.Resource,
+          domain: nil,
+          data_layer: AshPostgres.DataLayer,
+          extensions: [AshPostgresBelongsToIndex],
+          validate_domain_inclusion?: false
+
+        postgres do
+          table "resource_with_manual_refs"
+          repo AshPostgresBelongsToIndex.Test.Support.TestResources.TestRepo
+
+          references do
+            reference :company, on_delete: :delete
+            reference :user, on_delete: :nilify
+          end
+        end
+
+        attributes do
+          uuid_primary_key :id
+          attribute :name, :string
+        end
+
+        relationships do
+          belongs_to :company,
+                     AshPostgresBelongsToIndex.Test.Support.TestResources.CompanyResource
+
+          belongs_to :user, AshPostgresBelongsToIndex.Test.Support.TestResources.UserResource
+          belongs_to :depot, AshPostgresBelongsToIndex.Test.Support.TestResources.DepotResource
+        end
+      end
+
+      dsl_state = ResourceWithManualRefs.spark_dsl_config()
+      {:ok, transformed_state} = Transformer.transform(dsl_state)
+
+      references = DslTransformer.get_entities(transformed_state, [:postgres, :references])
+
+      custom_indexes =
+        DslTransformer.get_entities(transformed_state, [:postgres, :custom_indexes])
+
+      # Should keep original manual references unchanged
+      # 2 original + 1 new for depot
+      assert length(references) == 3
+
+      # Should create custom indexes for company and user (which have manual refs)
+      company_index = Enum.find(custom_indexes, &(&1.fields == [:company_id]))
+      user_index = Enum.find(custom_indexes, &(&1.fields == [:user_id]))
+
+      assert company_index != nil
+      assert user_index != nil
+
+      # Should create indexed reference for depot (which doesn't have manual ref)
+      depot_ref = Enum.find(references, &(&1.relationship == :depot))
+      assert depot_ref.index? == true
+    end
+
+    test "handles multitenant resources correctly" do
+      # Define a multitenant resource
+      defmodule MultitenantResource do
+        use Ash.Resource,
+          domain: nil,
+          data_layer: AshPostgres.DataLayer,
+          extensions: [AshPostgresBelongsToIndex],
+          validate_domain_inclusion?: false
+
+        postgres do
+          table "multitenant_resource"
+          repo AshPostgresBelongsToIndex.Test.Support.TestResources.TestRepo
+
+          references do
+            reference :company, on_delete: :delete
+          end
+        end
+
+        multitenancy do
+          strategy :attribute
+          attribute :company_id
+        end
+
+        attributes do
+          uuid_primary_key :id
+          attribute :name, :string
+        end
+
+        relationships do
+          belongs_to :company,
+                     AshPostgresBelongsToIndex.Test.Support.TestResources.CompanyResource
+
+          belongs_to :user, AshPostgresBelongsToIndex.Test.Support.TestResources.UserResource
+          belongs_to :depot, AshPostgresBelongsToIndex.Test.Support.TestResources.DepotResource
+        end
+      end
+
+      dsl_state = MultitenantResource.spark_dsl_config()
+      {:ok, transformed_state} = Transformer.transform(dsl_state)
+
+      custom_indexes =
+        DslTransformer.get_entities(transformed_state, [:postgres, :custom_indexes])
+
+      references = DslTransformer.get_entities(transformed_state, [:postgres, :references])
+
+      # Company should NOT get any index because its FK is the same as tenant attribute
+      # (the belongs_to :company would use company_id, which is also the tenant attribute)
+      company_index =
+        Enum.find(custom_indexes, fn index ->
+          index.fields == [:company_id] or index.fields == [:company_id, :company_id]
+        end)
+
+      # Company should be filtered out by get_belongs_toes since source_attribute == multitenant_attr
+      assert company_index == nil
+
+      # User and depot should get indexed references (no manual refs)
+      user_ref = Enum.find(references, &(&1.relationship == :user))
+      depot_ref = Enum.find(references, &(&1.relationship == :depot))
+
+      assert user_ref.index? == true
+      assert depot_ref.index? == true
+    end
+
+    test "respects except list configuration" do
+      # Define a resource with except configuration
+      defmodule ResourceWithExcept do
+        use Ash.Resource,
+          domain: nil,
+          data_layer: AshPostgres.DataLayer,
+          extensions: [AshPostgresBelongsToIndex],
+          validate_domain_inclusion?: false
+
+        postgres do
+          table "resource_with_except"
+          repo AshPostgresBelongsToIndex.Test.Support.TestResources.TestRepo
+        end
+
+        postgres_belongs_to_index do
+          except [:user]
+        end
+
+        attributes do
+          uuid_primary_key :id
+          attribute :name, :string
+        end
+
+        relationships do
+          belongs_to :company,
+                     AshPostgresBelongsToIndex.Test.Support.TestResources.CompanyResource
+
+          belongs_to :user, AshPostgresBelongsToIndex.Test.Support.TestResources.UserResource
+          belongs_to :depot, AshPostgresBelongsToIndex.Test.Support.TestResources.DepotResource
+        end
+      end
+
+      dsl_state = ResourceWithExcept.spark_dsl_config()
+      {:ok, transformed_state} = Transformer.transform(dsl_state)
+
+      references = DslTransformer.get_entities(transformed_state, [:postgres, :references])
+
+      # Should create references for company and depot, but not user
+      company_ref = Enum.find(references, &(&1.relationship == :company))
+      depot_ref = Enum.find(references, &(&1.relationship == :depot))
+      user_ref = Enum.find(references, &(&1.relationship == :user))
+
+      assert company_ref.index? == true
+      assert depot_ref.index? == true
+      # Should be excluded
+      assert user_ref == nil
+    end
+
+    test "skips relationships that already have indexed references" do
+      # Define a resource with an already indexed reference
+      defmodule ResourceWithIndexedRef do
+        use Ash.Resource,
+          domain: nil,
+          data_layer: AshPostgres.DataLayer,
+          extensions: [AshPostgresBelongsToIndex],
+          validate_domain_inclusion?: false
+
+        postgres do
+          table "resource_with_indexed_ref"
+          repo AshPostgresBelongsToIndex.Test.Support.TestResources.TestRepo
+
+          references do
+            reference :company, on_delete: :delete, index?: true
+          end
+        end
+
+        attributes do
+          uuid_primary_key :id
+          attribute :name, :string
+        end
+
+        relationships do
+          belongs_to :company,
+                     AshPostgresBelongsToIndex.Test.Support.TestResources.CompanyResource
+
+          belongs_to :user, AshPostgresBelongsToIndex.Test.Support.TestResources.UserResource
+        end
+      end
+
+      dsl_state = ResourceWithIndexedRef.spark_dsl_config()
+      {:ok, transformed_state} = Transformer.transform(dsl_state)
+
+      references = DslTransformer.get_entities(transformed_state, [:postgres, :references])
+
+      custom_indexes =
+        DslTransformer.get_entities(transformed_state, [:postgres, :custom_indexes])
+
+      # Should have 2 references: original company + new user
+      assert length(references) == 2
+
+      # Company should keep its existing indexed reference
+      company_refs = Enum.filter(references, &(&1.relationship == :company))
+      assert length(company_refs) == 1
+      assert hd(company_refs).index? == true
+
+      # User should get new indexed reference
+      user_ref = Enum.find(references, &(&1.relationship == :user))
+      assert user_ref.index? == true
+
+      # Should not create any custom indexes
+      assert length(custom_indexes) == 0
+    end
+
+    test "detects existing custom indexes and skips FK coverage" do
+      # Define a resource with existing custom index covering FK
+      defmodule ResourceWithCustomIndex do
+        use Ash.Resource,
+          domain: nil,
+          data_layer: AshPostgres.DataLayer,
+          extensions: [AshPostgresBelongsToIndex],
+          validate_domain_inclusion?: false
+
+        postgres do
+          table "resource_with_custom_index"
+          repo AshPostgresBelongsToIndex.Test.Support.TestResources.TestRepo
+
+          custom_indexes do
+            # Covers company FK
+            index [:company_id]
+          end
+        end
+
+        multitenancy do
+          strategy :attribute
+          attribute :company_id
+        end
+
+        attributes do
+          uuid_primary_key :id
+          attribute :name, :string
+        end
+
+        relationships do
+          belongs_to :company,
+                     AshPostgresBelongsToIndex.Test.Support.TestResources.CompanyResource
+
+          belongs_to :user, AshPostgresBelongsToIndex.Test.Support.TestResources.UserResource
+        end
+      end
+
+      dsl_state = ResourceWithCustomIndex.spark_dsl_config()
+      {:ok, transformed_state} = Transformer.transform(dsl_state)
+
+      references = DslTransformer.get_entities(transformed_state, [:postgres, :references])
+
+      custom_indexes =
+        DslTransformer.get_entities(transformed_state, [:postgres, :custom_indexes])
+
+      # Should only create reference for user (company already covered by custom index)
+      user_ref = Enum.find(references, &(&1.relationship == :user))
+      company_ref = Enum.find(references, &(&1.relationship == :company))
+
+      assert user_ref.index? == true
+      # Should not create reference for company
+      assert company_ref == nil
+
+      # Should have original custom index + no new ones for company
+      company_indexes =
+        Enum.filter(custom_indexes, fn index ->
+          index.fields == [:company_id] or index.fields == [:company_id, :company_id]
+        end)
+
+      # Only the original
+      assert length(company_indexes) == 1
+    end
+
+    test "handles non-multitenant resources correctly" do
+      # Define a non-multitenant resource
+      defmodule NonMultitenantResource do
+        use Ash.Resource,
+          domain: nil,
+          data_layer: AshPostgres.DataLayer,
+          extensions: [AshPostgresBelongsToIndex],
+          validate_domain_inclusion?: false
+
+        postgres do
+          table "non_multitenant_resource"
+          repo AshPostgresBelongsToIndex.Test.Support.TestResources.TestRepo
+
+          references do
+            reference :company, on_delete: :delete
+          end
+        end
+
+        attributes do
+          uuid_primary_key :id
+          attribute :name, :string
+        end
+
+        relationships do
+          belongs_to :company,
+                     AshPostgresBelongsToIndex.Test.Support.TestResources.CompanyResource
+
+          belongs_to :user, AshPostgresBelongsToIndex.Test.Support.TestResources.UserResource
+        end
+      end
+
+      dsl_state = NonMultitenantResource.spark_dsl_config()
+      {:ok, transformed_state} = Transformer.transform(dsl_state)
+
+      custom_indexes =
+        DslTransformer.get_entities(transformed_state, [:postgres, :custom_indexes])
+
+      references = DslTransformer.get_entities(transformed_state, [:postgres, :references])
+
+      # Company should get simple custom index (no tenant prefix)
+      company_index = Enum.find(custom_indexes, &(&1.fields == [:company_id]))
+      assert company_index != nil
+
+      # User should get indexed reference
+      user_ref = Enum.find(references, &(&1.relationship == :user))
+      assert user_ref.index? == true
+    end
+  end
+
+  describe "multitenant resource tests" do
+    test "creates indexed references for multitenant resource without manual references" do
+      # Test the dedicated multitenant resource
+      dsl_state =
+        AshPostgresBelongsToIndex.Test.Support.TestResources.MultitenantOrderResource.spark_dsl_config()
+
+      {:ok, transformed_state} = Transformer.transform(dsl_state)
+
+      references = DslTransformer.get_entities(transformed_state, [:postgres, :references])
+
+      custom_indexes =
+        DslTransformer.get_entities(transformed_state, [:postgres, :custom_indexes])
+
+      # Should create indexed references for user and depot (no manual refs)
+      user_ref = Enum.find(references, &(&1.relationship == :user))
+      depot_ref = Enum.find(references, &(&1.relationship == :depot))
+
+      assert user_ref.index? == true
+      assert depot_ref.index? == true
+
+      # Company relationship should be filtered out (company_id == tenant attribute)
+      company_ref = Enum.find(references, &(&1.relationship == :company))
+      assert company_ref == nil
+
+      # Should not create any custom indexes since no manual references
+      assert length(custom_indexes) == 0
+    end
+
+    test "creates custom indexes for multitenant resource with manual references" do
+      # Test the dedicated multitenant resource with manual references
+      dsl_state =
+        AshPostgresBelongsToIndex.Test.Support.TestResources.MultitenantOrderWithRefsResource.spark_dsl_config()
+
+      {:ok, transformed_state} = Transformer.transform(dsl_state)
+
+      references = DslTransformer.get_entities(transformed_state, [:postgres, :references])
+
+      custom_indexes =
+        DslTransformer.get_entities(transformed_state, [:postgres, :custom_indexes])
+
+      # Should have original manual references + new indexed reference for depot
+      depot_ref = Enum.find(references, &(&1.relationship == :depot))
+      assert depot_ref.index? == true
+
+      # Should create custom indexes for user (has manual ref but no index?)
+      user_index = Enum.find(custom_indexes, &(&1.fields == [:company_id, :user_id]))
+      assert user_index != nil
+
+      # Company should be filtered out (company_id == tenant attribute)
+      company_index =
+        Enum.find(custom_indexes, fn index ->
+          index.fields == [:company_id] or index.fields == [:company_id, :company_id]
+        end)
+
+      assert company_index == nil
+    end
+
+    test "verifies composite index structure for multitenant resources" do
+      # Test that multitenant resources create proper composite indexes
+      dsl_state =
+        AshPostgresBelongsToIndex.Test.Support.TestResources.MultitenantOrderWithRefsResource.spark_dsl_config()
+
+      {:ok, transformed_state} = Transformer.transform(dsl_state)
+
+      custom_indexes =
+        DslTransformer.get_entities(transformed_state, [:postgres, :custom_indexes])
+
+      # User index should be composite: [:company_id, :user_id]
+      user_index = Enum.find(custom_indexes, &(&1.fields == [:company_id, :user_id]))
+      assert user_index != nil
+      assert user_index.fields == [:company_id, :user_id]
+
+      # Should not create simple indexes for FK that have manual references in multitenant
+      simple_user_index = Enum.find(custom_indexes, &(&1.fields == [:user_id]))
+      assert simple_user_index == nil
+    end
+  end
+
+  describe "helper functions" do
+    test "fk_already_indexed? detects composite indexes correctly" do
+      # This tests the private function indirectly through transformer behavior
+      # Already covered by the custom index test above
+      assert true
+    end
+
+    test "get_belongs_toes filters out multitenant attribute correctly" do
+      # This tests the belongs_to filtering logic
+      # Covered by multitenant tests above
+      assert true
+    end
+  end
+end

--- a/test/transformer_test.exs
+++ b/test/transformer_test.exs
@@ -178,6 +178,9 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
 
       assert user_single_index != nil
       assert depot_single_index != nil
+
+      assert user_single_index.all_tenants? == true
+      assert depot_single_index.all_tenants? == true
     end
 
     test "respects except list configuration" do
@@ -431,6 +434,9 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
 
       assert user_single_index != nil
       assert depot_single_index != nil
+
+      assert user_single_index.all_tenants? == true
+      assert depot_single_index.all_tenants? == true
     end
 
     test "creates custom indexes for multitenant resource with manual references" do
@@ -452,6 +458,7 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
       # Should create composite custom index for user (has manual ref but no index?)
       user_composite_index = Enum.find(custom_indexes, &(&1.fields == [:company_id, :user_id]))
       assert user_composite_index != nil
+      assert user_composite_index.all_tenants? == true
 
       # Should also create single-column custom indexes for multitenant FK enforcement
       user_single_index = Enum.find(custom_indexes, &(&1.fields == [:user_id]))
@@ -459,6 +466,9 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
 
       assert user_single_index != nil
       assert depot_single_index != nil
+
+      assert user_single_index.all_tenants? == true
+      assert depot_single_index.all_tenants? == true
 
       # Company should be filtered out (company_id == tenant attribute)
       company_index =
@@ -483,10 +493,179 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
       user_index = Enum.find(custom_indexes, &(&1.fields == [:company_id, :user_id]))
       assert user_index != nil
       assert user_index.fields == [:company_id, :user_id]
+      assert user_index.all_tenants? == true
 
       # Should also create single-column indexes for multitenant FK enforcement
       simple_user_index = Enum.find(custom_indexes, &(&1.fields == [:user_id]))
       assert simple_user_index != nil
+      assert simple_user_index.all_tenants? == true
+    end
+  end
+
+  describe "multitenancy index prefixing" do
+    test "creates single-column index when non-all_tenants index exists on same field" do
+      defmodule MultitenantWithNonAllTenantsIndex do
+        use Ash.Resource,
+          domain: nil,
+          data_layer: AshPostgres.DataLayer,
+          extensions: [AshPostgresBelongsToIndex],
+          validate_domain_inclusion?: false
+
+        postgres do
+          table "mt_with_non_all_tenants_index"
+          repo AshPostgresBelongsToIndex.Test.Support.TestResources.TestRepo
+
+          custom_indexes do
+            index [:depot_id]
+          end
+        end
+
+        multitenancy do
+          strategy :attribute
+          attribute :company_id
+        end
+
+        attributes do
+          uuid_primary_key :id
+        end
+
+        relationships do
+          belongs_to :company,
+                     AshPostgresBelongsToIndex.Test.Support.TestResources.CompanyResource
+
+          belongs_to :depot, AshPostgresBelongsToIndex.Test.Support.TestResources.DepotResource
+        end
+      end
+
+      dsl_state = MultitenantWithNonAllTenantsIndex.spark_dsl_config()
+      {:ok, transformed_state} = Transformer.transform(dsl_state)
+
+      custom_indexes =
+        DslTransformer.get_entities(transformed_state, [:postgres, :custom_indexes])
+
+      # The user-defined `index [:depot_id]` (without all_tenants?) will effectively be
+      # [:company_id, :depot_id] in the database due to tenant prefixing.
+      # So the plugin should STILL create a single-column [:depot_id] with all_tenants?: true
+      depot_single_index =
+        Enum.find(custom_indexes, fn idx ->
+          idx.fields == [:depot_id] && idx.all_tenants? == true
+        end)
+
+      assert depot_single_index != nil
+    end
+
+    test "recognizes non-all_tenants index as effective composite and does not duplicate it" do
+      defmodule MultitenantWithEffectiveComposite do
+        use Ash.Resource,
+          domain: nil,
+          data_layer: AshPostgres.DataLayer,
+          extensions: [AshPostgresBelongsToIndex],
+          validate_domain_inclusion?: false
+
+        postgres do
+          table "mt_with_effective_composite"
+          repo AshPostgresBelongsToIndex.Test.Support.TestResources.TestRepo
+
+          custom_indexes do
+            index [:depot_id]
+          end
+
+          references do
+            reference :depot, on_delete: :delete
+          end
+        end
+
+        multitenancy do
+          strategy :attribute
+          attribute :company_id
+        end
+
+        attributes do
+          uuid_primary_key :id
+        end
+
+        relationships do
+          belongs_to :company,
+                     AshPostgresBelongsToIndex.Test.Support.TestResources.CompanyResource
+
+          belongs_to :depot, AshPostgresBelongsToIndex.Test.Support.TestResources.DepotResource
+        end
+      end
+
+      dsl_state = MultitenantWithEffectiveComposite.spark_dsl_config()
+      {:ok, transformed_state} = Transformer.transform(dsl_state)
+
+      custom_indexes =
+        DslTransformer.get_entities(transformed_state, [:postgres, :custom_indexes])
+
+      # The user-defined `index [:depot_id]` (without all_tenants?) effectively creates
+      # [:company_id, :depot_id] in the DB. The plugin should NOT create a duplicate
+      # explicit composite [:company_id, :depot_id] index.
+      explicit_composite =
+        Enum.find(custom_indexes, fn idx ->
+          idx.fields == [:company_id, :depot_id]
+        end)
+
+      assert explicit_composite == nil
+
+      # Should still create single-column [:depot_id] with all_tenants?: true
+      depot_single =
+        Enum.find(custom_indexes, fn idx ->
+          idx.fields == [:depot_id] && idx.all_tenants? == true
+        end)
+
+      assert depot_single != nil
+    end
+
+    test "composite index added via manual-ref path has all_tenants? true" do
+      defmodule MultitenantManualRefComposite do
+        use Ash.Resource,
+          domain: nil,
+          data_layer: AshPostgres.DataLayer,
+          extensions: [AshPostgresBelongsToIndex],
+          validate_domain_inclusion?: false
+
+        postgres do
+          table "mt_manual_ref_composite"
+          repo AshPostgresBelongsToIndex.Test.Support.TestResources.TestRepo
+
+          references do
+            reference :user, on_delete: :nilify
+          end
+        end
+
+        multitenancy do
+          strategy :attribute
+          attribute :company_id
+        end
+
+        attributes do
+          uuid_primary_key :id
+        end
+
+        relationships do
+          belongs_to :company,
+                     AshPostgresBelongsToIndex.Test.Support.TestResources.CompanyResource
+
+          belongs_to :user, AshPostgresBelongsToIndex.Test.Support.TestResources.UserResource
+        end
+      end
+
+      dsl_state = MultitenantManualRefComposite.spark_dsl_config()
+      {:ok, transformed_state} = Transformer.transform(dsl_state)
+
+      custom_indexes =
+        DslTransformer.get_entities(transformed_state, [:postgres, :custom_indexes])
+
+      # The plugin creates composite [:company_id, :user_id] via manual-ref path.
+      # It should have all_tenants?: true to prevent Ash from double-prefixing.
+      composite_index =
+        Enum.find(custom_indexes, fn idx ->
+          idx.fields == [:company_id, :user_id]
+        end)
+
+      assert composite_index != nil
+      assert composite_index.all_tenants? == true
     end
   end
 

--- a/test/transformer_test.exs
+++ b/test/transformer_test.exs
@@ -155,15 +155,23 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
 
       references = DslTransformer.get_entities(transformed_state, [:postgres, :references])
 
-      # Company should NOT get any index because its FK is the same as tenant attribute
-      # (the belongs_to :company would use company_id, which is also the tenant attribute)
+      # Company should NOT get a separate single-column index because the indexed
+      # references for user and depot already create indexes starting with company_id
+      # (e.g., [:company_id, :user_id]) which can satisfy FK lookups via leftmost prefix.
       company_index =
         Enum.find(custom_indexes, fn index ->
-          index.fields == [:company_id] or index.fields == [:company_id, :company_id]
+          index.fields == [:company_id]
         end)
 
-      # Company should be filtered out by get_belongs_toes since source_attribute == multitenant_attr
       assert company_index == nil
+
+      # Should NOT create redundant composite index [:company_id, :company_id]
+      redundant_company_index =
+        Enum.find(custom_indexes, fn index ->
+          index.fields == [:company_id, :company_id]
+        end)
+
+      assert redundant_company_index == nil
 
       # User and depot should get indexed references (no manual refs)
       user_ref = Enum.find(references, &(&1.relationship == :user))
@@ -422,16 +430,20 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
       assert user_ref.index? == true
       assert depot_ref.index? == true
 
-      # Company relationship should be filtered out (company_id == tenant attribute)
+      # Company relationship should NOT get an indexed reference (source_attr == tenant_attr)
       company_ref = Enum.find(references, &(&1.relationship == :company))
       assert company_ref == nil
 
-      # Should create single-column custom indexes for multitenant FK enforcement
+      # Should create single-column custom indexes for user and depot only.
+      # Company does NOT need a separate index because the user/depot indexed references
+      # already create indexes starting with company_id (leftmost prefix rule).
       assert length(custom_indexes) == 2
 
+      company_single_index = Enum.find(custom_indexes, &(&1.fields == [:company_id]))
       user_single_index = Enum.find(custom_indexes, &(&1.fields == [:user_id]))
       depot_single_index = Enum.find(custom_indexes, &(&1.fields == [:depot_id]))
 
+      assert company_single_index == nil
       assert user_single_index != nil
       assert depot_single_index != nil
 
@@ -469,13 +481,22 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
       assert user_single_index.all_tenants? == true
       assert depot_single_index.all_tenants? == true
 
-      # Company should be filtered out (company_id == tenant attribute)
-      company_index =
+      # Company should NOT get a separate single-column index because other
+      # relationships create indexes starting with company_id (leftmost prefix rule)
+      company_single_index =
         Enum.find(custom_indexes, fn index ->
-          index.fields == [:company_id] or index.fields == [:company_id, :company_id]
+          index.fields == [:company_id]
         end)
 
-      assert company_index == nil
+      assert company_single_index == nil
+
+      # Should NOT create redundant composite index [:company_id, :company_id]
+      redundant_company_index =
+        Enum.find(custom_indexes, fn index ->
+          index.fields == [:company_id, :company_id]
+        end)
+
+      assert redundant_company_index == nil
     end
 
     test "verifies composite index structure for multitenant resources" do
@@ -665,6 +686,57 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
 
       assert composite_index != nil
       refute composite_index.all_tenants?
+    end
+  end
+
+  describe "company-only resources" do
+    test "creates single-column company_id index when no other relationships exist" do
+      # This tests resources like custom_zones and pods that ONLY have belongs_to :company
+      # Since there are no other relationships to create indexed references,
+      # we need an explicit [:company_id] index for FK enforcement.
+      defmodule CompanyOnlyResource do
+        use Ash.Resource,
+          domain: nil,
+          data_layer: AshPostgres.DataLayer,
+          extensions: [AshPostgresBelongsToIndex],
+          validate_domain_inclusion?: false
+
+        postgres do
+          table "company_only_resource"
+          repo AshPostgresBelongsToIndex.Test.Support.TestResources.TestRepo
+        end
+
+        multitenancy do
+          strategy :attribute
+          attribute :company_id
+        end
+
+        attributes do
+          uuid_primary_key :id
+          attribute :name, :string
+        end
+
+        relationships do
+          belongs_to :company,
+                     AshPostgresBelongsToIndex.Test.Support.TestResources.CompanyResource
+        end
+      end
+
+      dsl_state = CompanyOnlyResource.spark_dsl_config()
+      {:ok, transformed_state} = Transformer.transform(dsl_state)
+
+      custom_indexes =
+        DslTransformer.get_entities(transformed_state, [:postgres, :custom_indexes])
+
+      references = DslTransformer.get_entities(transformed_state, [:postgres, :references])
+
+      # No indexed references should be created (company relationship skips composite)
+      assert Enum.empty?(references)
+
+      # SHOULD create single-column [:company_id] index because no other index covers it
+      company_index = Enum.find(custom_indexes, &(&1.fields == [:company_id]))
+      assert company_index != nil
+      assert company_index.all_tenants? == true
     end
   end
 

--- a/test/transformer_test.exs
+++ b/test/transformer_test.exs
@@ -171,6 +171,13 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
 
       assert user_ref.index? == true
       assert depot_ref.index? == true
+
+      # Should also create single-column custom indexes for multitenant FK enforcement
+      user_single_index = Enum.find(custom_indexes, &(&1.fields == [:user_id]))
+      depot_single_index = Enum.find(custom_indexes, &(&1.fields == [:depot_id]))
+
+      assert user_single_index != nil
+      assert depot_single_index != nil
     end
 
     test "respects except list configuration" do
@@ -337,6 +344,10 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
 
       # Only the original
       assert length(company_indexes) == 1
+
+      # Should also create single-column custom index for user FK enforcement
+      user_single_index = Enum.find(custom_indexes, &(&1.fields == [:user_id]))
+      assert user_single_index != nil
     end
 
     test "handles non-multitenant resources correctly" do
@@ -412,8 +423,14 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
       company_ref = Enum.find(references, &(&1.relationship == :company))
       assert company_ref == nil
 
-      # Should not create any custom indexes since no manual references
-      assert length(custom_indexes) == 0
+      # Should create single-column custom indexes for multitenant FK enforcement
+      assert length(custom_indexes) == 2
+
+      user_single_index = Enum.find(custom_indexes, &(&1.fields == [:user_id]))
+      depot_single_index = Enum.find(custom_indexes, &(&1.fields == [:depot_id]))
+
+      assert user_single_index != nil
+      assert depot_single_index != nil
     end
 
     test "creates custom indexes for multitenant resource with manual references" do
@@ -432,9 +449,16 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
       depot_ref = Enum.find(references, &(&1.relationship == :depot))
       assert depot_ref.index? == true
 
-      # Should create custom indexes for user (has manual ref but no index?)
-      user_index = Enum.find(custom_indexes, &(&1.fields == [:company_id, :user_id]))
-      assert user_index != nil
+      # Should create composite custom index for user (has manual ref but no index?)
+      user_composite_index = Enum.find(custom_indexes, &(&1.fields == [:company_id, :user_id]))
+      assert user_composite_index != nil
+
+      # Should also create single-column custom indexes for multitenant FK enforcement
+      user_single_index = Enum.find(custom_indexes, &(&1.fields == [:user_id]))
+      depot_single_index = Enum.find(custom_indexes, &(&1.fields == [:depot_id]))
+
+      assert user_single_index != nil
+      assert depot_single_index != nil
 
       # Company should be filtered out (company_id == tenant attribute)
       company_index =
@@ -460,9 +484,9 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
       assert user_index != nil
       assert user_index.fields == [:company_id, :user_id]
 
-      # Should not create simple indexes for FK that have manual references in multitenant
+      # Should also create single-column indexes for multitenant FK enforcement
       simple_user_index = Enum.find(custom_indexes, &(&1.fields == [:user_id]))
-      assert simple_user_index == nil
+      assert simple_user_index != nil
     end
   end
 

--- a/test/transformer_test.exs
+++ b/test/transformer_test.exs
@@ -458,7 +458,6 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
       # Should create composite custom index for user (has manual ref but no index?)
       user_composite_index = Enum.find(custom_indexes, &(&1.fields == [:company_id, :user_id]))
       assert user_composite_index != nil
-      assert user_composite_index.all_tenants? == true
 
       # Should also create single-column custom indexes for multitenant FK enforcement
       user_single_index = Enum.find(custom_indexes, &(&1.fields == [:user_id]))
@@ -493,7 +492,6 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
       user_index = Enum.find(custom_indexes, &(&1.fields == [:company_id, :user_id]))
       assert user_index != nil
       assert user_index.fields == [:company_id, :user_id]
-      assert user_index.all_tenants? == true
 
       # Should also create single-column indexes for multitenant FK enforcement
       simple_user_index = Enum.find(custom_indexes, &(&1.fields == [:user_id]))
@@ -617,7 +615,7 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
       assert depot_single != nil
     end
 
-    test "composite index added via manual-ref path has all_tenants? true" do
+    test "composite index added via manual-ref path does not set all_tenants?" do
       defmodule MultitenantManualRefComposite do
         use Ash.Resource,
           domain: nil,
@@ -658,14 +656,15 @@ defmodule AshPostgresBelongsToIndex.TransformerTest do
         DslTransformer.get_entities(transformed_state, [:postgres, :custom_indexes])
 
       # The plugin creates composite [:company_id, :user_id] via manual-ref path.
-      # It should have all_tenants?: true to prevent Ash from double-prefixing.
+      # It does NOT set all_tenants? because Enum.uniq in index_keys already
+      # prevents double-prefixing. Not setting it avoids snapshot diff noise.
       composite_index =
         Enum.find(custom_indexes, fn idx ->
           idx.fields == [:company_id, :user_id]
         end)
 
       assert composite_index != nil
-      assert composite_index.all_tenants? == true
+      refute composite_index.all_tenants?
     end
   end
 


### PR DESCRIPTION
Was being told by my DB performance tool that we were missing 99 FK indexes. Tbh, I assumed that Ash would create them automatically as my previous two ORMs did so as well.

Was about to start adding them, but started wondering if something  else in the Ash ecosystem already handled this and found your plugin. Thanks for that :)

Realized quickly though that it skipped any custom indexes and we use those quite a bit, so decided to extend it a bit plus added (auto generated but inspired on the ash codebase) tests for it.

What do you think? I can verify it handles:
```elixir
reference :foo, on_delete: :delete #ignored
```
but also

```elixir
    custom_indexes do
      index [:fk_id, :created_at] # composite index
    end
```

and 

```elixir
  multitenancy do
    strategy :attribute
    attribute :bar_id
  end

  relationships do
    belongs_to :foo, MyApp.Bar do
      allow_nil? false
      public? true
    end
end
```

correctly results in index :
```elixir
create_index foo_bar [foo_id, bar_id]
```